### PR TITLE
[FEAT] 카카오 로그인 중간 단계 #1

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -42,6 +42,9 @@ jobs:
           cloud.aws.s3.region.static: ${{ secrets.S3_REGION }}
           cloud.aws.s3.credentials.accessKey: ${{ secrets.S3_ACCESS_KEY }}
           cloud.aws.s3.credentials.secretKey: ${{ secrets.S3_PRIVATE_KEY }}
+          security.oauth2.client.registration.kakao.client-id: ${{ secrets.KAKAO_CLIENT_ID }}
+          security.oauth2.client.registration.kakao.client-secret: ${{ secrets.KAKAO_CLIENT_SECRET }}
+
 
       - name: 4)Grant permission
         run: chmod +x ./gradlew

--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,15 @@ dependencies {
 	//AWS
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 	implementation 'com.amazonaws:aws-java-sdk-s3:1.12.490'
+
+	//jwt
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+	//security
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	testImplementation 'org.springframework.security:spring-security-test'
 }
 
 tasks.named('test') {

--- a/src/main/java/coollaafi/wot/apiPayload/ApiResponse.java
+++ b/src/main/java/coollaafi/wot/apiPayload/ApiResponse.java
@@ -1,0 +1,37 @@
+package coollaafi.wot.apiPayload;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import coollaafi.wot.apiPayload.code.BaseCode;
+import coollaafi.wot.apiPayload.code.status.SuccessStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@JsonPropertyOrder({"isSuccess", "code", "message", "result"})
+public class ApiResponse<T> {
+
+    @JsonProperty("isSuccess")
+    private final Boolean isSuccess;
+    private final String code;
+    private final String message;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private T result;
+
+
+    // 성공한 경우 응답 생성
+    public static <T> ApiResponse<T> onSuccess(T result){
+        return new ApiResponse<>(true, SuccessStatus._OK.getCode() , SuccessStatus._OK.getMessage(), result);
+    }
+
+    public static <T> ApiResponse<T> of(BaseCode code, T result){
+            return new ApiResponse<>(true, code.getReasonHttpStatus().getCode() , code.getReasonHttpStatus().getMessage(), result);
+    }
+
+    // 실패한 경우 응답 생성
+    public static <T> ApiResponse<T> onFailure(String code, String message, T data){
+        return new ApiResponse<>(true, code, message, data);
+    }
+}

--- a/src/main/java/coollaafi/wot/apiPayload/code/BaseCode.java
+++ b/src/main/java/coollaafi/wot/apiPayload/code/BaseCode.java
@@ -1,0 +1,8 @@
+package coollaafi.wot.apiPayload.code;
+
+public interface BaseCode {
+
+    public ReasonDTO getReason();
+
+    public ReasonDTO getReasonHttpStatus();
+}

--- a/src/main/java/coollaafi/wot/apiPayload/code/BaseErrorCode.java
+++ b/src/main/java/coollaafi/wot/apiPayload/code/BaseErrorCode.java
@@ -1,0 +1,8 @@
+package coollaafi.wot.apiPayload.code;
+
+public interface BaseErrorCode {
+
+    public ErrorReasonDTO getReason();
+
+    public ErrorReasonDTO getReasonHttpStatus();
+}

--- a/src/main/java/coollaafi/wot/apiPayload/code/ErrorReasonDTO.java
+++ b/src/main/java/coollaafi/wot/apiPayload/code/ErrorReasonDTO.java
@@ -1,0 +1,18 @@
+package coollaafi.wot.apiPayload.code;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ErrorReasonDTO {
+    private String message;
+    private String code;
+    private Boolean isSuccess;
+    private HttpStatus httpStatus;
+}

--- a/src/main/java/coollaafi/wot/apiPayload/code/ReasonDTO.java
+++ b/src/main/java/coollaafi/wot/apiPayload/code/ReasonDTO.java
@@ -1,0 +1,18 @@
+package coollaafi.wot.apiPayload.code;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReasonDTO {
+    private String message;
+    private String code;
+    private Boolean isSuccess;
+    private HttpStatus httpStatus;
+}

--- a/src/main/java/coollaafi/wot/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/coollaafi/wot/apiPayload/code/status/ErrorStatus.java
@@ -1,0 +1,49 @@
+package coollaafi.wot.apiPayload.code.status;
+
+import coollaafi.wot.apiPayload.code.BaseErrorCode;
+import coollaafi.wot.apiPayload.code.ErrorReasonDTO;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorStatus implements BaseErrorCode {
+    // 가장 일반적인 응답
+    _INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 에러, 관리자에게 문의 바랍니다."),
+    _BAD_REQUEST(HttpStatus.BAD_REQUEST,"COMMON400","잘못된 요청입니다."),
+    _UNAUTHORIZED(HttpStatus.UNAUTHORIZED,"COMMON401","인증이 필요합니다."),
+    _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
+
+
+    //Exception 핸들링 테스트
+    TEMP_EXCEPTION(HttpStatus.BAD_REQUEST, "TEMP4001", "에러 핸들링 테스트"),
+
+    //추가
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ErrorReasonDTO getReason() {
+        return ErrorReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .build();
+    }
+
+    @Override
+    public ErrorReasonDTO getReasonHttpStatus() {
+        return ErrorReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .httpStatus(httpStatus)
+                .build()
+                ;
+    }
+
+}

--- a/src/main/java/coollaafi/wot/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/coollaafi/wot/apiPayload/code/status/SuccessStatus.java
@@ -1,0 +1,39 @@
+package coollaafi.wot.apiPayload.code.status;
+
+import coollaafi.wot.apiPayload.code.BaseCode;
+import coollaafi.wot.apiPayload.code.ReasonDTO;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum SuccessStatus implements BaseCode {
+    //가장 일반적인 응답
+    _OK(HttpStatus.OK, "COMMON200", "성공입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ReasonDTO getReason(){
+        return ReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(true)
+                .build()
+                ;
+    }
+
+    @Override
+    public ReasonDTO getReasonHttpStatus(){
+        return ReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(true)
+                .httpStatus(httpStatus)
+                .build()
+                ;
+    }
+}

--- a/src/main/java/coollaafi/wot/apiPayload/exception/ExceptionAdvice.java
+++ b/src/main/java/coollaafi/wot/apiPayload/exception/ExceptionAdvice.java
@@ -1,0 +1,121 @@
+package coollaafi.wot.apiPayload.exception;
+
+import coollaafi.wot.apiPayload.ApiResponse;
+import coollaafi.wot.apiPayload.code.ErrorReasonDTO;
+import coollaafi.wot.apiPayload.code.status.ErrorStatus;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.ConstraintViolationException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+@Slf4j
+@RestControllerAdvice(annotations = {RestController.class})
+public class ExceptionAdvice extends ResponseEntityExceptionHandler {
+
+
+    @ExceptionHandler
+    public ResponseEntity<Object> validation(ConstraintViolationException e, WebRequest request) {
+        String errorMessage = e.getConstraintViolations().stream()
+                .map(constraintViolation -> constraintViolation.getMessage())
+                .findFirst()
+                .orElseThrow(() -> new RuntimeException("ConstraintViolationException 추출 도중 에러 발생"));
+
+        return handleExceptionInternalConstraint(e, ErrorStatus.valueOf(errorMessage), HttpHeaders.EMPTY,request);
+    }
+
+
+    @Override
+    public ResponseEntity<Object> handleMethodArgumentNotValid(
+            MethodArgumentNotValidException e, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+
+        Map<String, String> errors = new LinkedHashMap<>();
+
+        e.getBindingResult().getFieldErrors().stream()
+                .forEach(fieldError -> {
+                    String fieldName = fieldError.getField();
+                    String errorMessage = Optional.ofNullable(fieldError.getDefaultMessage()).orElse("");
+                    errors.merge(fieldName, errorMessage, (existingErrorMessage, newErrorMessage) -> existingErrorMessage + ", " + newErrorMessage);
+                });
+
+        return handleExceptionInternalArgs(e,HttpHeaders.EMPTY, ErrorStatus.valueOf("_BAD_REQUEST"),request,errors);
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<Object> exception(Exception e, WebRequest request) {
+        e.printStackTrace();
+
+        return handleExceptionInternalFalse(e, ErrorStatus._INTERNAL_SERVER_ERROR, HttpHeaders.EMPTY, ErrorStatus._INTERNAL_SERVER_ERROR.getHttpStatus(),request, e.getMessage());
+    }
+
+    @ExceptionHandler(value = GeneralException.class)
+    public ResponseEntity onThrowException(GeneralException generalException, HttpServletRequest request) {
+        ErrorReasonDTO errorReasonHttpStatus = generalException.getErrorReasonHttpStatus();
+        return handleExceptionInternal(generalException,errorReasonHttpStatus,null,request);
+    }
+
+    private ResponseEntity<Object> handleExceptionInternal(Exception e, ErrorReasonDTO reason,
+                                                           HttpHeaders headers, HttpServletRequest request) {
+
+        ApiResponse<Object> body = ApiResponse.onFailure(reason.getCode(),reason.getMessage(),null);
+//        e.printStackTrace();
+
+        WebRequest webRequest = new ServletWebRequest(request);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                reason.getHttpStatus(),
+                webRequest
+        );
+    }
+
+    private ResponseEntity<Object> handleExceptionInternalFalse(Exception e, ErrorStatus errorCommonStatus,
+                                                                HttpHeaders headers, HttpStatus status, WebRequest request, String errorPoint) {
+        ApiResponse<Object> body = ApiResponse.onFailure(errorCommonStatus.getCode(),errorCommonStatus.getMessage(),errorPoint);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                status,
+                request
+        );
+    }
+
+    private ResponseEntity<Object> handleExceptionInternalArgs(Exception e, HttpHeaders headers, ErrorStatus errorCommonStatus,
+                                                               WebRequest request, Map<String, String> errorArgs) {
+        ApiResponse<Object> body = ApiResponse.onFailure(errorCommonStatus.getCode(),errorCommonStatus.getMessage(),errorArgs);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                errorCommonStatus.getHttpStatus(),
+                request
+        );
+    }
+
+    private ResponseEntity<Object> handleExceptionInternalConstraint(Exception e, ErrorStatus errorCommonStatus,
+                                                                     HttpHeaders headers, WebRequest request) {
+        ApiResponse<Object> body = ApiResponse.onFailure(errorCommonStatus.getCode(), errorCommonStatus.getMessage(), null);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                errorCommonStatus.getHttpStatus(),
+                request
+        );
+    }
+}

--- a/src/main/java/coollaafi/wot/apiPayload/exception/GeneralException.java
+++ b/src/main/java/coollaafi/wot/apiPayload/exception/GeneralException.java
@@ -1,0 +1,26 @@
+package coollaafi.wot.apiPayload.exception;
+
+import coollaafi.wot.apiPayload.code.BaseErrorCode;
+import coollaafi.wot.apiPayload.code.ErrorReasonDTO;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class GeneralException extends RuntimeException {
+
+    private BaseErrorCode code;
+
+    public GeneralException(String message) {
+        super(message);
+    }
+
+    public ErrorReasonDTO
+    getErrorReason(){
+        return this.code.getReason();
+    }
+
+    public ErrorReasonDTO getErrorReasonHttpStatus(){
+        return this.code.getReasonHttpStatus();
+    }
+}

--- a/src/main/java/coollaafi/wot/apiPayload/exception/handler/TempHandler.java
+++ b/src/main/java/coollaafi/wot/apiPayload/exception/handler/TempHandler.java
@@ -1,0 +1,11 @@
+package coollaafi.wot.apiPayload.exception.handler;
+
+import coollaafi.wot.apiPayload.code.BaseErrorCode;
+import coollaafi.wot.apiPayload.exception.GeneralException;
+
+public class TempHandler extends GeneralException {
+
+    public TempHandler(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/coollaafi/wot/common/BaseEntity.java
+++ b/src/main/java/coollaafi/wot/common/BaseEntity.java
@@ -1,0 +1,29 @@
+package coollaafi.wot.common;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+	@CreatedDate
+	private LocalDateTime createdAt;
+	@LastModifiedDate
+	private LocalDateTime updatedAt;
+
+	public BaseEntity() {
+	}
+
+	public LocalDateTime getCreatedAt() {
+		return this.createdAt;
+	}
+
+	public LocalDateTime getUpdatedAt() {
+		return this.updatedAt;
+	}
+}

--- a/src/main/java/coollaafi/wot/config/S3Config.java
+++ b/src/main/java/coollaafi/wot/config/S3Config.java
@@ -11,13 +11,13 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class S3Config {
 
-    @Value("${cloud.aws.credentials.accessKey}")
+    @Value("${cloud.aws.s3.credentials.accessKey}")
     private String accessKey;
 
-    @Value("${cloud.aws.credentials.secretKey}")
+    @Value("${cloud.aws.s3.credentials.secretKey}")
     private String secretKey;
 
-    @Value("${cloud.aws.region.static}")
+    @Value("${cloud.aws.s3.region.static}")
     private String region;
 
     @Bean

--- a/src/main/java/coollaafi/wot/config/SecurityConfig.java
+++ b/src/main/java/coollaafi/wot/config/SecurityConfig.java
@@ -1,0 +1,48 @@
+package coollaafi.wot.config;
+
+import coollaafi.wot.jwt.JwtTokenProvider;
+import coollaafi.wot.jwt.JwtVerifyFilter;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@EnableWebSecurity
+@Configuration
+public class SecurityConfig {
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public SecurityConfig(JwtTokenProvider jwtTokenProvider) {
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .authorizeHttpRequests(requests -> requests
+                        .requestMatchers("/login", "/login/oauth2/code/kakao", "/test", "/h2-console/**", "/kakao", "/swagger-ui/index.html", "/swagger-ui/**", "/v3/api-docs/**","/swagger-resources/**", "/v3/api-docs").permitAll()  // /login URL은 인증 없이 접근 가능
+                        .anyRequest().authenticated()           // 나머지 URL은 인증 필요
+                )
+                .addFilterBefore(new JwtVerifyFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class)
+                .formLogin(form -> form
+                        .loginPage("/login")                    // 커스텀 로그인 페이지 설정
+                        .permitAll()
+                )
+                .logout(logout -> logout.permitAll())
+                .exceptionHandling(exception -> exception
+                        .authenticationEntryPoint((request, response, authException) ->
+                                response.sendError(HttpServletResponse.SC_UNAUTHORIZED)) // 인증되지 않은 사용자가 보호된 페이지에 접근할 때 401 Unauthorized 에러 반환
+                )
+                .csrf(csrf -> csrf
+                        .ignoringRequestMatchers("/h2-console/**")) // CSRF 보호 비활성화
+                .headers(headers -> headers
+                        .frameOptions(frameOptions -> frameOptions
+                                .sameOrigin())); // H2 콘솔의 프레임 옵션 허용
+
+        return http.build();
+    }
+}

--- a/src/main/java/coollaafi/wot/jwt/AuthTokens.java
+++ b/src/main/java/coollaafi/wot/jwt/AuthTokens.java
@@ -1,0 +1,21 @@
+package coollaafi.wot.jwt;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AuthTokens {
+    private String accessToken;
+    private String refreshToken;
+    private String grantType;
+    private Long expiresIn;
+
+    public static AuthTokens of(String accessToken, String refreshToken, String grantType, Long expiresIn) {
+        return new AuthTokens(accessToken, refreshToken, grantType, expiresIn);
+    }
+}

--- a/src/main/java/coollaafi/wot/jwt/AuthTokensGenerator.java
+++ b/src/main/java/coollaafi/wot/jwt/AuthTokensGenerator.java
@@ -1,0 +1,28 @@
+package coollaafi.wot.jwt;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Date;
+
+@Component
+@RequiredArgsConstructor
+public class AuthTokensGenerator {
+    private static final String BEARER_TYPE = "Bearer";
+    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 60;	//1시간
+    private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 14;  // 14일
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    //id 받아 Access Token 생성
+    public AuthTokens generate(String uid) {
+        long now = (new Date()).getTime();
+        Date accessTokenExpiredAt = new Date(now + ACCESS_TOKEN_EXPIRE_TIME);
+        Date refreshTokenExpiredAt = new Date(now + REFRESH_TOKEN_EXPIRE_TIME);
+
+        String accessToken = jwtTokenProvider.accessTokenGenerate(uid, accessTokenExpiredAt);
+        String refreshToken = jwtTokenProvider.refreshTokenGenerate(refreshTokenExpiredAt);
+
+        return AuthTokens.of(accessToken, refreshToken, BEARER_TYPE, ACCESS_TOKEN_EXPIRE_TIME / 1000L);
+    }
+}

--- a/src/main/java/coollaafi/wot/jwt/JwtTokenProvider.java
+++ b/src/main/java/coollaafi/wot/jwt/JwtTokenProvider.java
@@ -1,0 +1,77 @@
+package coollaafi.wot.jwt;
+
+import coollaafi.wot.apiPayload.exception.GeneralException;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Date;
+import java.util.List;
+
+@Component
+public class JwtTokenProvider {
+    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+    private final Key key;
+
+    public JwtTokenProvider(@Value("wVtm60YHDIV4GbVtxK3rE59xDZqLLtsjT4nIlPwvW1p3vIjN2jHFZ3VcZ7vTXnZqjF8hJf9vJ8Jf9jF8hJf9J8Jf9vJ8Jf9jF") String secretKey) {
+        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    public String accessTokenGenerate(String subject, Date expiredAt) {
+        return Jwts.builder()
+                .setSubject(subject)	//uid
+                .setExpiration(expiredAt)
+                .signWith(key, SignatureAlgorithm.HS512)
+                .compact();
+    }
+    public String refreshTokenGenerate(Date expiredAt) {
+        return Jwts.builder()
+                .setExpiration(expiredAt)
+                .signWith(key, SignatureAlgorithm.HS512)
+                .compact();
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        } catch (ExpiredJwtException e) {
+            throw new GeneralException("The token has expired.");
+        } catch (JwtException | IllegalArgumentException e) {
+            throw new GeneralException("The token is not valid.");
+        }
+    }
+
+    public Authentication getAuthentication(String token) {
+        Claims claims = Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody();
+        String username = claims.getSubject();
+
+        if (username == null) {
+            throw new GeneralException("The token is not valid.");
+        }
+
+        UserDetails userDetails = User.builder()
+                .username(username)
+                .password("") // password는 필요없으므로 빈 문자열
+                .authorities(List.of()) // authorities를 설정할 경우 추가
+                .build();
+
+        return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
+    }
+
+    public static void checkAuthorizationHeader(String header) {
+        if (header == null || !header.startsWith("Bearer ")) {
+            throw new GeneralException("Token not delivered."); // 토큰 전달되지 않았을 때 메시지
+        }
+    }
+}

--- a/src/main/java/coollaafi/wot/jwt/JwtVerifyFilter.java
+++ b/src/main/java/coollaafi/wot/jwt/JwtVerifyFilter.java
@@ -1,0 +1,53 @@
+package coollaafi.wot.jwt;
+
+import coollaafi.wot.apiPayload.exception.GeneralException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.PatternMatchUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+import java.io.IOException;
+
+public class JwtVerifyFilter extends OncePerRequestFilter {
+    private static final String[] whitelist = {"/login/oauth2/code/kakao", "/kakao", "/h2-console/**", "/swagger-ui/index.html", "/swagger-ui/**", "/v3/api-docs/**","/swagger-resources/**", "/v3/api-docs"};
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public JwtVerifyFilter(JwtTokenProvider jwtTokenProvider) {
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+        String requestURI = request.getRequestURI();
+        return PatternMatchUtils.simpleMatch(whitelist, requestURI);
+    }
+
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        String header = request.getHeader("Authorization");
+
+        try {
+            JwtTokenProvider.checkAuthorizationHeader(header);
+            String token = header.substring(7);
+
+            if (!jwtTokenProvider.validateToken(token)) {
+                throw new GeneralException("The token is not valid.");
+            }
+
+            SecurityContextHolder.getContext().setAuthentication(jwtTokenProvider.getAuthentication(token));
+        } catch (GeneralException e) {
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            response.setContentType("application/json; charset=UTF-8");
+            response.getWriter().write("{\"message\": \"" + e.getMessage() + "\", \"code\": \"UNAUTHORIZED\"}");
+            return;
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/coollaafi/wot/kakao/KakaoService.java
+++ b/src/main/java/coollaafi/wot/kakao/KakaoService.java
@@ -1,4 +1,4 @@
-package coollaafi.wot.login.service;
+package coollaafi.wot.kakao;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/src/main/java/coollaafi/wot/login/controller/LoginController.java
+++ b/src/main/java/coollaafi/wot/login/controller/LoginController.java
@@ -1,0 +1,44 @@
+package coollaafi.wot.login.controller;
+
+import coollaafi.wot.login.service.KakaoService;
+import coollaafi.wot.login.dto.LoginResponseDTO;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.view.RedirectView;
+
+@RestController
+public class LoginController {
+    private final KakaoService kakaoService;
+
+    @Value("${security.oauth2.client.registration.kakao.redirect-uri}")
+    private String redirectUri;
+
+    @Value("${security.oauth2.client.registration.kakao.client-id}")
+    private String kakaoClientId;
+
+    @Autowired
+    public LoginController(KakaoService kakaoService) {
+        this.kakaoService = kakaoService;
+    };
+
+
+    @GetMapping("/login")
+    public String login() {
+        return "Hello World";
+    }
+
+
+    @GetMapping("/login/oauth2/code/kakao")
+    public LoginResponseDTO kakao(@RequestParam("code") String code) {
+        return kakaoService.kakaoLogin(code, redirectUri);
+    }
+
+    @GetMapping("/kakao")
+    public RedirectView kakaoLogin() {
+        String kakaoLoginUrl = "https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=" + kakaoClientId + "&redirect_uri=" + redirectUri;
+        return new RedirectView(kakaoLoginUrl);
+    }
+}

--- a/src/main/java/coollaafi/wot/login/controller/LoginController.java
+++ b/src/main/java/coollaafi/wot/login/controller/LoginController.java
@@ -1,6 +1,6 @@
 package coollaafi.wot.login.controller;
 
-import coollaafi.wot.login.service.KakaoService;
+import coollaafi.wot.kakao.KakaoService;
 import coollaafi.wot.login.dto.LoginResponseDTO;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;

--- a/src/main/java/coollaafi/wot/login/dto/LoginResponseDTO.java
+++ b/src/main/java/coollaafi/wot/login/dto/LoginResponseDTO.java
@@ -1,0 +1,19 @@
+package coollaafi.wot.login.dto;
+
+
+import coollaafi.wot.jwt.AuthTokens;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class LoginResponseDTO {
+    private Long id;
+    private AuthTokens token;
+
+    public LoginResponseDTO(Long id, AuthTokens token) {
+        this.id = id;
+        this.token = token;
+    }
+
+}

--- a/src/main/java/coollaafi/wot/login/service/KakaoService.java
+++ b/src/main/java/coollaafi/wot/login/service/KakaoService.java
@@ -1,0 +1,150 @@
+package coollaafi.wot.login.service;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import coollaafi.wot.jwt.AuthTokens;
+import coollaafi.wot.jwt.AuthTokensGenerator;
+import coollaafi.wot.jwt.JwtTokenProvider;
+import coollaafi.wot.login.dto.LoginResponseDTO;
+import coollaafi.wot.member.repository.MemberRepository;
+import coollaafi.wot.member.entity.Member;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.HashMap;
+
+@RequiredArgsConstructor
+@Service
+public class KakaoService {
+    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+
+    private final MemberRepository memberRepository;
+    private final AuthTokensGenerator authTokensGenerator;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Value("${security.oauth2.client.registration.kakao.client-id}")
+    private String clientId;
+
+    @Value("${security.oauth2.client.registration.kakao.client-secret}")
+    private String clientSecret;
+
+    public LoginResponseDTO kakaoLogin(String code, String redirectUri) {
+        // 1. "인가 코드"로 "액세스 토큰" 요청
+        String accessToken = getAccessToken(code, redirectUri);
+
+        // 2. 토큰으로 카카오 API 호출
+        HashMap<String, Object> userInfo = getKakaoUserInfo(accessToken);
+
+        // 3. 카카오ID로 회원가입 & 로그인 처리
+        LoginResponseDTO kakaoUserResponse = kakaoUserLogin(userInfo);
+
+        return kakaoUserResponse;
+    }
+
+    // 1. "인가 코드"로 "액세스 토큰" 요청
+    private String getAccessToken(String code, String redirectUri) {
+        logger.info("Requesting access token with code: {} and redirectUri: {}", code, redirectUri);
+
+        // HTTP Header 생성
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        // HTTP Body 생성
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("grant_type", "authorization_code");
+        body.add("client_id", clientId);
+        body.add("redirect_uri", redirectUri);
+        body.add("code", code);
+        body.add("client_secret", clientSecret);
+
+        // HTTP 요청 보내기
+        HttpEntity<MultiValueMap<String, String>> kakaoTokenRequest = new HttpEntity<>(body, headers);
+        RestTemplate rt = new RestTemplate();
+        ResponseEntity<String> response;
+        try {
+            response = rt.exchange(
+                    "https://kauth.kakao.com/oauth/token",
+                    HttpMethod.POST,
+                    kakaoTokenRequest,
+                    String.class
+            );
+            logger.info("Received response: {}", response.getBody());
+        } catch (HttpClientErrorException e) {
+            logger.error("HTTP error: " + e.getStatusCode() + " - " + e.getResponseBodyAsString());
+            throw e;
+        } catch (Exception e) {
+            logger.error("Error occurred while requesting access token: " + e.getMessage());
+            throw new RuntimeException(e);
+        }
+
+        String responseBody = response.getBody();
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode jsonNode;
+        try {
+            jsonNode = objectMapper.readTree(responseBody);
+        } catch (JsonProcessingException e) {
+            logger.error("Error parsing JSON response: " + e.getMessage());
+            throw new RuntimeException(e);
+        }
+        return jsonNode.get("access_token").asText();
+    }
+
+    // 2. 토큰으로 카카오 API 호출
+    private HashMap<String, Object> getKakaoUserInfo(String accessToken) {
+        HashMap<String, Object> userInfo = new HashMap<>();
+
+        // HTTP Header 생성
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Authorization", "Bearer " + accessToken);
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        // HTTP 요청 보내기
+        HttpEntity<MultiValueMap<String, String>> kakaoUserInfoRequest = new HttpEntity<>(headers);
+        RestTemplate rt = new RestTemplate();
+        ResponseEntity<String> response = rt.exchange(
+                "https://kapi.kakao.com/v2/user/me",
+                HttpMethod.POST,
+                kakaoUserInfoRequest,
+                String.class
+        );
+
+        String responseBody = response.getBody();
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode jsonNode;
+        try {
+            jsonNode = objectMapper.readTree(responseBody);
+        } catch (JsonProcessingException e) {
+            logger.error("Error parsing JSON response: " + e.getMessage());
+            throw new RuntimeException(e);
+        }
+
+        Long id = jsonNode.get("id").asLong();
+        System.out.println(id);
+        userInfo.put("id", id);
+
+        return userInfo;
+    }
+
+    // 3. 카카오ID로 회원가입 & 로그인 처리
+    private LoginResponseDTO kakaoUserLogin(HashMap<String, Object> userInfo) {
+        Long uid = Long.valueOf(userInfo.get("id").toString());
+        Member kakaoUser = memberRepository.findById(uid).orElse(null);
+
+        if (kakaoUser == null) {
+            kakaoUser = new Member();
+            kakaoUser.setId(uid);
+            memberRepository.save(kakaoUser);
+        }
+
+        AuthTokens token = authTokensGenerator.generate(uid.toString());
+        return new LoginResponseDTO(uid, token);
+    }
+}

--- a/src/main/java/coollaafi/wot/member/entity/Member.java
+++ b/src/main/java/coollaafi/wot/member/entity/Member.java
@@ -1,0 +1,30 @@
+package coollaafi.wot.member.entity;
+
+import coollaafi.wot.common.BaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.net.URL;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@Entity
+public class Member extends BaseEntity {
+    @Id
+    @GeneratedValue(
+            strategy = GenerationType.IDENTITY
+    )
+    private Long id;
+
+    private String name;
+
+    private URL profileimage;
+}

--- a/src/main/java/coollaafi/wot/member/entity/Member.java
+++ b/src/main/java/coollaafi/wot/member/entity/Member.java
@@ -1,10 +1,7 @@
 package coollaafi.wot.member.entity;
 
 import coollaafi.wot.common.BaseEntity;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -27,4 +24,7 @@ public class Member extends BaseEntity {
     private String name;
 
     private URL profileimage;
+
+    @Column(unique = true)
+    private String accessToken;
 }

--- a/src/main/java/coollaafi/wot/member/repository/MemberRepository.java
+++ b/src/main/java/coollaafi/wot/member/repository/MemberRepository.java
@@ -1,0 +1,12 @@
+package coollaafi.wot.member.repository;
+
+import coollaafi.wot.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findById(Long id);
+}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -28,3 +28,20 @@ cloud:
       credentials:
         accessKey: {accesskey}
         secretKey: {secretkey}
+
+security:
+  oauth2:
+    client:
+      registration:
+        kakao:
+          client-id: ${kakao.client.id}
+          client-secret: ${kakao.client.secret}
+          authorization-grant-type: authorization_code
+          redirect-uri: http://localhost:8080/login/oauth2/code/kakao
+          client-authentication-method: client_secret_post
+      provider:
+        kakao:
+          authorization-uri: https://kauth.kakao.com/oauth/authorize
+          token-uri: https://kauth.kakao.com/oauth/token
+          user-info-uri: https://kapi.kakao.com/v2/user/me
+          user-name-attribute: id


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- #1

## 🔑 Key Changes

1. 내용
    - 카카오 로그인 처리
    - 멤버 엔티티 생성
    - 에러 핸들러 및 응답 통일 설정

## 📸 Screenshot


